### PR TITLE
Generate-job resilience (ghost processes) + alpha-check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Generate-page jobs now survive the server dying.** All job state (subprocess handle,
+  event log) lived only in the web server's process memory, so if `viewer/serve.py` itself
+  crashed or was closed mid-run — which happened twice on 2026-08-20, once as a silent
+  death and once as a false "stuck" alarm that turned out to be a slow-but-healthy run —
+  there was nothing on disk to say a job was in flight, and its detached subprocess
+  (`start_new_session=True`, so Cancel can `killpg` it independently) could be left running
+  as an untracked ghost. Each job now writes `<job-dir>/pid` the moment its subprocess
+  starts; on the next server startup, `_reconcile_orphaned_jobs` finds any leftover pid
+  files, kills whichever processes are still alive, and annotates that job's `run.log`
+  either way so it stops trailing off silently. A clean shutdown (Ctrl-C, `kill`) now also
+  kills the active job's process group before exiting, via new `SIGTERM`/`SIGINT` handlers
+  in `serve.py` — previously only `SIGINT` was even caught, and neither one touched the
+  child.
+
 ### Changed
 - **Xiong's Hunyuan3D-MLX shape+paint port moved from `vendor/hunyuan-mlx-paint`
   (git-ignored) into this repo's tracked tree at `hunyuan_mlx/`.** It's MIT-licensed code,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recommendation (weaker DINOv2-large conditioner). See `docs/hunyuan-mlx-recipes.md`.
 
 ### Fixed
+- **Generate mode's alpha-transparency check silently blamed the image when Pillow wasn't
+  installed.** `image_has_transparent_alpha()`'s bare `except Exception` caught a missing
+  Pillow import the same as a genuinely opaque image, so on any interpreter without Pillow
+  every upload failed the check — "no transparent alpha foreground" — regardless of
+  whether the image had real transparency. Confirmed on `leather_satchel.png`: alpha range
+  0–255, but the server's own interpreter had no PIL at all. Now raises a clear,
+  actionable error instead of a wrong 422. Quick start updated to set up a small venv with
+  Pillow for exactly this reason — a bare `pip install Pillow` outside a venv refuses to
+  run at all on Homebrew Python.
 - **Generate page showed no progress at all during Hunyuan's shape stage.**
   `_hunyuan_parse_line` only recognized paint-stage print lines plus a single
   `"shape generated"` completion marker for the *entire* shape stage — the shape

--- a/README.md
+++ b/README.md
@@ -37,14 +37,7 @@ python3 -m venv .venv && .venv/bin/pip install Pillow
 # opens http://127.0.0.1:8777/viewer/index.html
 ```
 
-The server itself (`viewer/serve.py`) is otherwise standard-library-only — **Compare**
-mode needs nothing beyond a working Python 3. **Generate** mode is the one exception: it
-needs Pillow importable in that same interpreter for the pre-upload alpha-transparency
-check, or every image fails that check regardless of whether it actually has a transparent
-background. On Homebrew's Python a bare `pip install Pillow` outside a venv refuses to run
-at all (`externally-managed-environment`), which is why the venv above isn't optional. Each
-backend's own much heavier dependencies (PyTorch, etc.) live in their own separate venvs,
-set up per-backend below — none of that is needed just to open the viewer.
+That's it — no other deps needed until you pick a backend below.
 
 Go to **Generate**, pick a backend from the dropdown. Each one has its own **Setup**
 status telling you exactly what's missing:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,19 @@ Working to see how we can be more colour accurate.
 
 ```bash
 git clone <repo> && cd image-to-3dlab
-python viewer/serve.py
+python3 -m venv .venv && .venv/bin/pip install Pillow
+.venv/bin/python viewer/serve.py
 # opens http://127.0.0.1:8777/viewer/index.html
 ```
+
+The server itself (`viewer/serve.py`) is otherwise standard-library-only — **Compare**
+mode needs nothing beyond a working Python 3. **Generate** mode is the one exception: it
+needs Pillow importable in that same interpreter for the pre-upload alpha-transparency
+check, or every image fails that check regardless of whether it actually has a transparent
+background. On Homebrew's Python a bare `pip install Pillow` outside a venv refuses to run
+at all (`externally-managed-environment`), which is why the venv above isn't optional. Each
+backend's own much heavier dependencies (PyTorch, etc.) live in their own separate venvs,
+set up per-backend below — none of that is needed just to open the viewer.
 
 Go to **Generate**, pick a backend from the dropdown. Each one has its own **Setup**
 status telling you exactly what's missing:

--- a/tests/test_viewer_generate_api.py
+++ b/tests/test_viewer_generate_api.py
@@ -391,6 +391,71 @@ def test_remove_pid_file_is_a_noop_when_missing(tmp_path):
     api._remove_pid_file(tmp_path)  # must not raise
 
 
+# --- startup reconciliation of pid files a dead server left behind ---------------------
+
+def test_reconcile_annotates_and_clears_a_dead_orphan(tmp_path, monkeypatch):
+    job_dir = tmp_path / "some-job"
+    job_dir.mkdir()
+    (job_dir / "pid").write_text("4242")
+    (job_dir / "run.log").write_text("views decoded (100s)\n")
+    monkeypatch.setattr(api.os, "killpg", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+
+    touched = api._reconcile_orphaned_jobs(tmp_path)
+
+    assert touched == ["some-job"]
+    assert not (job_dir / "pid").exists()
+    assert "died mid-run" in (job_dir / "run.log").read_text()
+
+
+def test_reconcile_kills_and_annotates_a_live_orphan(tmp_path, monkeypatch):
+    job_dir = tmp_path / "live-job"
+    job_dir.mkdir()
+    (job_dir / "pid").write_text("4242")
+    (job_dir / "run.log").write_text("step 3/15\n")
+    killed = []
+
+    def fake_killpg(pid, sig):
+        if sig == api.signal.SIGTERM:
+            killed.append((pid, sig))
+        # sig == 0 (the liveness probe) raises nothing -- simulates a live process group
+
+    monkeypatch.setattr(api.os, "killpg", fake_killpg)
+
+    touched = api._reconcile_orphaned_jobs(tmp_path)
+
+    assert touched == ["live-job"]
+    assert killed == [(4242, api.signal.SIGTERM)]
+    assert "orphaned generation" in (job_dir / "run.log").read_text()
+    assert not (job_dir / "pid").exists()
+
+
+def test_reconcile_survives_a_missing_run_log(tmp_path, monkeypatch):
+    job_dir = tmp_path / "no-log-job"
+    job_dir.mkdir()
+    (job_dir / "pid").write_text("4242")
+    monkeypatch.setattr(api.os, "killpg", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+
+    touched = api._reconcile_orphaned_jobs(tmp_path)
+
+    assert touched == ["no-log-job"]
+    assert not (job_dir / "pid").exists()
+
+
+def test_reconcile_discards_an_unparseable_pid_file(tmp_path):
+    job_dir = tmp_path / "bad-pid-job"
+    job_dir.mkdir()
+    (job_dir / "pid").write_text("not-a-pid")
+
+    touched = api._reconcile_orphaned_jobs(tmp_path)
+
+    assert touched == []
+    assert not (job_dir / "pid").exists()
+
+
+def test_reconcile_is_a_noop_with_no_leftover_jobs(tmp_path):
+    assert api._reconcile_orphaned_jobs(tmp_path) == []
+
+
 def test_trellis_build_args_skips_resume_caches_unless_debug(tmp_path):
     settings = api.validate_settings({})
     job = api.Job("0" * 32, tmp_path, tmp_path / "in.png", tmp_path / "run.glb", settings,

--- a/tests/test_viewer_generate_api.py
+++ b/tests/test_viewer_generate_api.py
@@ -391,6 +391,54 @@ def test_remove_pid_file_is_a_noop_when_missing(tmp_path):
     api._remove_pid_file(tmp_path)  # must not raise
 
 
+# --- graceful-shutdown counterpart to orphan reconciliation ----------------------------
+
+class _FakeProcess:
+    def __init__(self, pid, alive=True):
+        self.pid = pid
+        self._alive = alive
+
+    def poll(self):
+        return None if self._alive else 0
+
+
+def test_terminate_active_job_kills_the_running_process_group(tmp_path, monkeypatch):
+    jobs = api.JobManager()
+    monkeypatch.setattr(api, "JOBS", jobs)
+    job = jobs.create(tmp_path / "in.png", {}, "trellis", "flicker", None, tmp_path)
+    job.process = _FakeProcess(4242)
+    killed = []
+    monkeypatch.setattr(api, "_killpg_if_alive", killed.append)
+
+    api._terminate_active_job()
+
+    assert killed == [4242]
+
+
+def test_terminate_active_job_is_a_noop_with_no_active_job(monkeypatch):
+    jobs = api.JobManager()
+    monkeypatch.setattr(api, "JOBS", jobs)
+    killed = []
+    monkeypatch.setattr(api, "_killpg_if_alive", killed.append)
+
+    api._terminate_active_job()  # must not raise
+
+    assert killed == []
+
+
+def test_terminate_active_job_is_a_noop_when_process_already_exited(tmp_path, monkeypatch):
+    jobs = api.JobManager()
+    monkeypatch.setattr(api, "JOBS", jobs)
+    job = jobs.create(tmp_path / "in.png", {}, "trellis", "flicker", None, tmp_path)
+    job.process = _FakeProcess(4242, alive=False)
+    killed = []
+    monkeypatch.setattr(api, "_killpg_if_alive", killed.append)
+
+    api._terminate_active_job()
+
+    assert killed == []
+
+
 # --- startup reconciliation of pid files a dead server left behind ---------------------
 
 def test_reconcile_annotates_and_clears_a_dead_orphan(tmp_path, monkeypatch):

--- a/tests/test_viewer_generate_api.py
+++ b/tests/test_viewer_generate_api.py
@@ -378,6 +378,19 @@ def test_cleanup_debug_files_keeps_only_output_glb(tmp_path):
     assert sorted(p.name for p in tmp_path.iterdir()) == ["run.glb"]
 
 
+# --- pid-file lifecycle (the anchor for orphan reconciliation on server restart) -------
+
+def test_pid_file_write_and_remove_roundtrip(tmp_path):
+    api._write_pid_file(tmp_path, 4242)
+    assert api._pid_file_path(tmp_path).read_text() == "4242"
+    api._remove_pid_file(tmp_path)
+    assert not api._pid_file_path(tmp_path).exists()
+
+
+def test_remove_pid_file_is_a_noop_when_missing(tmp_path):
+    api._remove_pid_file(tmp_path)  # must not raise
+
+
 def test_trellis_build_args_skips_resume_caches_unless_debug(tmp_path):
     settings = api.validate_settings({})
     job = api.Job("0" * 32, tmp_path, tmp_path / "in.png", tmp_path / "run.glb", settings,

--- a/tests/test_viewer_generate_api.py
+++ b/tests/test_viewer_generate_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import sys
 from pathlib import Path
@@ -376,6 +377,49 @@ def test_cleanup_debug_files_keeps_only_output_glb(tmp_path):
     (tmp_path / "run.log").write_text("log")
     api._cleanup_debug_files(job)
     assert sorted(p.name for p in tmp_path.iterdir()) == ["run.glb"]
+
+
+# --- alpha-transparency check: a missing Pillow install is a broken environment, not a
+# fact about the image (2026-08-20: this silently reported "no alpha" for every image) ---
+
+def test_image_has_transparent_alpha_raises_when_pillow_missing(tmp_path, monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("No module named 'PIL'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(RuntimeError, match="Pillow is not installed"):
+        api.image_has_transparent_alpha(tmp_path / "whatever.png")
+
+
+def test_image_has_transparent_alpha_true_for_real_transparency(tmp_path):
+    from PIL import Image
+
+    path = tmp_path / "transparent.png"
+    img = Image.new("RGBA", (4, 4), (255, 0, 0, 0))
+    img.save(path)
+    assert api.image_has_transparent_alpha(path) is True
+
+
+def test_image_has_transparent_alpha_false_for_fully_opaque_rgba(tmp_path):
+    from PIL import Image
+
+    path = tmp_path / "opaque.png"
+    img = Image.new("RGBA", (4, 4), (255, 0, 0, 255))
+    img.save(path)
+    assert api.image_has_transparent_alpha(path) is False
+
+
+def test_image_has_transparent_alpha_false_for_rgb_no_alpha_channel(tmp_path):
+    from PIL import Image
+
+    path = tmp_path / "rgb.png"
+    img = Image.new("RGB", (4, 4), (255, 0, 0))
+    img.save(path)
+    assert api.image_has_transparent_alpha(path) is False
 
 
 # --- pid-file lifecycle (the anchor for orphan reconciliation on server restart) -------

--- a/viewer/generate_api.py
+++ b/viewer/generate_api.py
@@ -656,6 +656,24 @@ def _cleanup_debug_files(job: Job) -> None:
             path.unlink(missing_ok=True)
 
 
+def _pid_file_path(directory: Path) -> Path:
+    return directory / "pid"
+
+
+def _write_pid_file(directory: Path, pid: int) -> None:
+    """Record the generator subprocess's pid on disk the moment it starts.
+
+    This is the only trace of a running job that survives the server process itself
+    dying (memory-only Job/JobManager state does not) -- see _reconcile_orphaned_jobs,
+    which reads this file back on the next server startup to find and clean up jobs
+    whose tracker died mid-run."""
+    _pid_file_path(directory).write_text(str(pid))
+
+
+def _remove_pid_file(directory: Path) -> None:
+    _pid_file_path(directory).unlink(missing_ok=True)
+
+
 def _run_job(job: Job) -> None:
     spec = BACKENDS[job.backend_id]
     args = [str(spec.interpreter), str(spec.wrapper), *spec.build_args(job)]
@@ -672,6 +690,7 @@ def _run_job(job: Job) -> None:
             bufsize=0,
             start_new_session=True,
         )
+        _write_pid_file(job.directory, job.process.pid)
         reader = threading.Thread(target=_read_process, args=(job,), daemon=True)
         reader.start()
         threading.Thread(target=_rss_monitor, args=(job,), daemon=True,
@@ -714,6 +733,7 @@ def _run_job(job: Job) -> None:
         job.status = "error"
         job.emit({"phase": "error", "message": str(exc)})
     finally:
+        _remove_pid_file(job.directory)
         JOBS.finish(job)
 
 

--- a/viewer/generate_api.py
+++ b/viewer/generate_api.py
@@ -674,6 +674,59 @@ def _remove_pid_file(directory: Path) -> None:
     _pid_file_path(directory).unlink(missing_ok=True)
 
 
+def _killpg_if_alive(pid: int) -> None:
+    """Best-effort SIGTERM to a process group; a pid that's already gone is not an error."""
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+
+
+def _process_group_alive(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)  # signal 0: existence check only, sends nothing
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just not ours to signal -- still alive for reporting purposes
+
+
+def _reconcile_orphaned_jobs(output_root: Path) -> list[str]:
+    """Resolve pid files left behind by a previous server life -- this server process died
+    mid-run (crash, closed terminal, etc.) before it could record a terminal outcome, same
+    failure shape as the leather_satchel/jesus_chibi incidents on 2026-08-20. Call once at
+    server startup, before serving.
+
+    For each leftover <job-dir>/pid: if that process group is still running, it's an actual
+    ghost (nobody has been tracking it since the old server died) -- kill it. Either way,
+    annotate that job's run.log so it stops trailing off silently, and remove the pid file
+    since this server now owns (or has just closed out) that job's fate.
+
+    Returns the touched job-folder names, for a one-line startup banner."""
+    touched = []
+    for pid_file in sorted(output_root.rglob("pid")):
+        directory = pid_file.parent
+        try:
+            pid = int(pid_file.read_text().strip())
+        except (OSError, ValueError):
+            pid_file.unlink(missing_ok=True)
+            continue
+        alive = _process_group_alive(pid)
+        if alive:
+            _killpg_if_alive(pid)
+            note = "orphaned generation from a previous server session, terminated on restart"
+        else:
+            note = "server died mid-run (previous session) -- job status unknown, treat as failed"
+        log_path = directory / "run.log"
+        if log_path.is_file():
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write(note + "\n")
+        pid_file.unlink(missing_ok=True)
+        touched.append(directory.name)
+    return touched
+
+
 def _run_job(job: Job) -> None:
     spec = BACKENDS[job.backend_id]
     args = [str(spec.interpreter), str(spec.wrapper), *spec.build_args(job)]
@@ -1404,9 +1457,6 @@ class Handler(SimpleHTTPRequestHandler):
         job.status = "cancelling"
         process = job.process
         if process is not None and process.poll() is None:
-            try:
-                os.killpg(process.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
+            _killpg_if_alive(process.pid)
         job.emit({"phase": "error", "message": "Cancellation requested"})
         self._send_json(202, {"job_id": job.id, "status": "cancelling"})

--- a/viewer/generate_api.py
+++ b/viewer/generate_api.py
@@ -692,6 +692,21 @@ def _process_group_alive(pid: int) -> bool:
         return True  # exists, just not ours to signal -- still alive for reporting purposes
 
 
+def _terminate_active_job() -> None:
+    """Kill the active job's process group, if one is running. Called on a clean server
+    shutdown (SIGTERM/SIGINT) so a deliberate stop doesn't leave the same kind of orphan
+    _reconcile_orphaned_jobs cleans up after a crash -- this is the graceful-exit half of
+    that same problem: a signal caught here means the pid file gets left behind (the job's
+    own finally block, in a background thread, may not get to run before the process
+    exits), but the next startup's reconciliation finds it, sees the process is already
+    dead, and annotates it correctly."""
+    job = JOBS.jobs.get(JOBS.active) if JOBS.active else None
+    if job is None or job.process is None:
+        return
+    if job.process.poll() is None:
+        _killpg_if_alive(job.process.pid)
+
+
 def _reconcile_orphaned_jobs(output_root: Path) -> list[str]:
     """Resolve pid files left behind by a previous server life -- this server process died
     mid-run (crash, closed terminal, etc.) before it could record a terminal outcome, same

--- a/viewer/generate_api.py
+++ b/viewer/generate_api.py
@@ -343,10 +343,24 @@ def validate_settings(raw: Any) -> dict[str, Any]:
 
 
 def image_has_transparent_alpha(path: Path) -> bool:
-    """Return whether an image has an actual (not merely opaque) alpha channel."""
+    """Return whether an image has an actual (not merely opaque) alpha channel.
+
+    Raises RuntimeError if Pillow itself isn't importable in this interpreter -- that's a
+    broken server environment, not a fact about the image, and must not be reported as one.
+    (2026-08-20: a bare `except Exception` here caught a missing Pillow install the same as
+    a genuinely opaque image, so every upload silently failed the alpha check on a
+    Pillow-less interpreter and users were told to enable rembg for images that already had
+    real transparency.)"""
     try:
         from PIL import Image
-
+    except ImportError as exc:
+        raise RuntimeError(
+            "Pillow is not installed in the interpreter running viewer/serve.py, so the "
+            "alpha-transparency check cannot run. Install it (`pip install Pillow`, or "
+            "`pip install -r requirements.txt`) into that same interpreter and restart "
+            "the server."
+        ) from exc
+    try:
         with Image.open(path) as image:
             if image.mode != "RGBA":
                 return False
@@ -1349,8 +1363,15 @@ class Handler(SimpleHTTPRequestHandler):
             image_path = provisional / f"input{suffix}"
             with image_path.open("wb") as handle:
                 handle.write(image_field["data"])
-            if (spec.requires_alpha and not image_has_transparent_alpha(image_path)
-                    and not settings.get("allow_rembg")):
+            try:
+                lacks_alpha = spec.requires_alpha and not image_has_transparent_alpha(image_path)
+            except RuntimeError as exc:
+                for child in provisional.iterdir():
+                    child.unlink()
+                provisional.rmdir()
+                self._send_json(500, {"error": str(exc)})
+                return
+            if lacks_alpha and not settings.get("allow_rembg"):
                 for child in provisional.iterdir():
                     child.unlink()
                 provisional.rmdir()

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # and when loaded by the test suite via importlib (script dir not on sys.path).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from generate_api import Handler
+from generate_api import OUTPUT_ROOT, Handler, _reconcile_orphaned_jobs
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -69,6 +69,15 @@ def main() -> int:
     url = compare_url(args.open, args.port, args.labels) if args.open else \
         f"http://127.0.0.1:{args.port}/viewer/index.html"
     print(url, flush=True)
+
+    # A prior server life may have died mid-generation (crash, closed terminal) without
+    # ever recording how that job ended, and its detached child can still be running with
+    # nobody tracking it -- resolve those before accepting new jobs.
+    if OUTPUT_ROOT.is_dir():
+        orphaned = _reconcile_orphaned_jobs(OUTPUT_ROOT)
+        if orphaned:
+            print(f"reconciled {len(orphaned)} orphaned job(s) from a previous session: "
+                  f"{', '.join(orphaned)}", flush=True)
 
     import functools
     handler = functools.partial(Handler, directory=str(REPO))

--- a/viewer/serve.py
+++ b/viewer/serve.py
@@ -15,6 +15,7 @@ automation, which means the agent can look at its own output instead of asking.
 from __future__ import annotations
 
 import argparse
+import signal
 import socketserver
 import sys
 import urllib.parse
@@ -25,7 +26,7 @@ from pathlib import Path
 # and when loaded by the test suite via importlib (script dir not on sys.path).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from generate_api import OUTPUT_ROOT, Handler, _reconcile_orphaned_jobs
+from generate_api import OUTPUT_ROOT, Handler, _reconcile_orphaned_jobs, _terminate_active_job
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -79,6 +80,16 @@ def main() -> int:
             print(f"reconciled {len(orphaned)} orphaned job(s) from a previous session: "
                   f"{', '.join(orphaned)}", flush=True)
 
+    # A deliberate stop (Ctrl-C, `kill`) must not orphan an in-flight job the way an
+    # uncaught crash does -- SIGTERM has no default Python handler (it would just kill this
+    # process outright, mid-job, with no chance to clean up), so both signals get one here.
+    def _handle_shutdown_signal(signum, frame):
+        _terminate_active_job()
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, _handle_shutdown_signal)
+    signal.signal(signal.SIGINT, _handle_shutdown_signal)
+
     import functools
     handler = functools.partial(Handler, directory=str(REPO))
     with ThreadingHTTPServer(("127.0.0.1", args.port), handler) as httpd:
@@ -87,7 +98,7 @@ def main() -> int:
         print(f"serving {REPO} — ctrl-c to stop", flush=True)
         try:
             httpd.serve_forever()
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, SystemExit):
             print("\nstopped")
     return 0
 


### PR DESCRIPTION
## Summary

Two independent fixes found while chasing down two real incidents today (a Hunyuan
generation that died silently, and one that looked stuck but wasn't):

**Ghost-process handling** — all job state used to live only in the web server's
process memory, so if `viewer/serve.py` itself died mid-run, nothing on disk recorded
that a job was in flight, and its detached subprocess could be left running untracked.
- Each job now writes `<job-dir>/pid` when its subprocess starts.
- On the next server startup, `_reconcile_orphaned_jobs` finds leftover pid files,
  kills any still-alive orphans, and annotates that job's `run.log` instead of letting
  it trail off silently.
- A clean shutdown (Ctrl-C, `kill`) now also kills the active job's process group via
  new `SIGTERM`/`SIGINT` handlers — previously only `SIGINT` was caught, and neither
  one touched the child.

**Alpha-transparency check fix** — `image_has_transparent_alpha()` had a bare
`except Exception` that caught a missing Pillow install the same as a genuinely opaque
image, so on any interpreter without Pillow every upload silently failed the check
("no transparent alpha foreground") regardless of the actual image. Confirmed on
`leather_satchel.png`: real alpha (range 0–255), but the check always returned `False`
because the server's interpreter had no PIL. Now raises a clear, actionable error
instead. README quick start updated with the one-line venv setup this always silently
required.

## Test plan
- [x] `pytest tests/test_viewer_generate_api.py tests/test_viewer_serve.py` — 86 passed
- [x] `ruff check` clean on all touched files
- [x] Smoke-tested shutdown signal handling live (started `serve.py`, sent `SIGTERM`,
      confirmed clean exit)
- [x] Verified `image_has_transparent_alpha` both with and without Pillow present,
      against a real transparent PNG