### PR TITLE
Fix Setup panel showing Xiong shape weights as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recommendation (weaker DINOv2-large conditioner). See `docs/hunyuan-mlx-recipes.md`.
 
 ### Fixed
+- **Setup panel showed all Hunyuan3D-MLX (Xiong, full pipeline) shape weights as missing,
+  even when downloaded.** `_hunyuan_xiong_readiness()`'s `weights` field was a flat
+  `{name: bool}` dict; the frontend indexes into it expecting `{label, present, human}`
+  objects (the shape every other backend uses). A JS boolean has no `.present`/`.label`
+  property, so the panel always took the "missing" branch and rendered the model name as
+  the literal string `"undefined"`. Confirmed on this repo's real weights: all three
+  models (2.1, 2.0, 2.0-turbo — 13.7 GB / 4.6 GB / 4.6 GB) were actually on disk the whole
+  time.
 - **Generate mode's alpha-transparency check silently blamed the image when Pillow wasn't
   installed.** `image_has_transparent_alpha()`'s bare `except Exception` caught a missing
   Pillow import the same as a genuinely opaque image, so on any interpreter without Pillow

--- a/tests/test_viewer_generate_api.py
+++ b/tests/test_viewer_generate_api.py
@@ -107,6 +107,39 @@ def test_setup_available_reports_missing_bootstrap(monkeypatch, tmp_path):
     assert ok is False and "bootstrap" in reason
 
 
+# --- hunyuan-mlx-xiong shape-weights status: must match the {label, present, human}
+# shape every backend's Setup-panel `weights` field uses (see weights_on_disk) --
+# 2026-08-20: this used to be a flat {name: bool} dict, and the frontend's
+# `Object.values(s.weights).map(repo => repo.present / repo.label)` silently rendered
+# "undefined ... not on disk" for all three models regardless of what was actually
+# downloaded, because a JS boolean has no .present/.label property ---
+def test_hunyuan_xiong_shape_weights_status_reports_present_and_missing(monkeypatch, tmp_path):
+    present_dir = tmp_path / "2.0"
+    present_dir.mkdir()
+    (present_dir / "model.safetensors").write_bytes(b"\x00" * 2048)
+    missing_dir = tmp_path / "2.1"  # never created
+    monkeypatch.setattr(api, "HUNYUAN_XIONG_SHAPE_MODELS", {"2.0": present_dir, "2.1": missing_dir})
+
+    status = api._hunyuan_xiong_shape_weights_status()
+
+    assert status["2.0"]["present"] is True
+    assert status["2.0"]["bytes"] == 2048
+    assert status["2.0"]["human"] == "2.0 KB"
+    assert isinstance(status["2.0"]["label"], str) and status["2.0"]["label"]
+    assert status["2.1"]["present"] is False
+    assert status["2.1"]["bytes"] == 0
+    assert isinstance(status["2.1"]["label"], str) and status["2.1"]["label"]
+
+
+def test_hunyuan_xiong_readiness_weights_field_has_label_and_present(monkeypatch, tmp_path):
+    """The exact shape the frontend indexes into -- a regression test for the undefined-row bug."""
+    monkeypatch.setattr(api, "HUNYUAN_XIONG_SHAPE_MODELS", {"2.0": tmp_path / "nope"})
+    result = api._hunyuan_xiong_readiness()
+    entry = result["weights"]["2.0"]
+    assert set(entry) >= {"label", "present", "human"}
+    assert entry["present"] is False
+
+
 def test_setup_run_exposes_the_job_sse_contract():
     run = api.SetupRun("0" * 32)
     run.status = "running"

--- a/viewer/generate_api.py
+++ b/viewer/generate_api.py
@@ -1135,9 +1135,28 @@ def _hunyuan_xiong_build_args(job: Job) -> list[str]:
     ]
 
 
+def _hunyuan_xiong_shape_weights_status() -> dict[str, dict[str, Any]]:
+    """Per-model shape-weights presence, in the {label, present, human} shape the Setup
+    panel's frontend expects for every backend's `weights` field (see weights_on_disk).
+
+    Previously this was a flat {name: bool} dict. Object.values(...) on that yields plain
+    JS booleans, and `repo.present` / `repo.label` on a boolean are just undefined -- so the
+    panel rendered all three models as "undefined ... not on disk" regardless of what was
+    actually downloaded (found 2026-08-20 via a real screenshot: three "undefined" rows on
+    a machine that in fact had weights present)."""
+    out: dict[str, dict[str, Any]] = {}
+    for name, path in HUNYUAN_XIONG_SHAPE_MODELS.items():
+        present = path.is_dir()
+        size = sum(f.stat().st_size for f in path.rglob("*") if f.is_file()) if present else 0
+        out[name] = {"label": f"Hunyuan3D-MLX shape weights ({name})", "present": present,
+                     "bytes": size, "human": _human_bytes(size)}
+    return out
+
+
 def _hunyuan_xiong_readiness() -> dict[str, Any]:
     shape_ok = HUNYUAN_XIONG_SHAPE_VENV.is_file() and HUNYUAN_XIONG_WRAPPER.is_file()
-    model_availability = {name: path.is_dir() for name, path in HUNYUAN_XIONG_SHAPE_MODELS.items()}
+    weights_status = _hunyuan_xiong_shape_weights_status()
+    model_availability = {name: info["present"] for name, info in weights_status.items()}
     any_model_ok = any(model_availability.values())
     default_model_ok = model_availability.get(HUNYUAN_XIONG_DEFAULT_SETTINGS["model"], False)
     paint_venv_ok = HUNYUAN_PAINT_VENV.is_file()
@@ -1174,7 +1193,7 @@ def _hunyuan_xiong_readiness() -> dict[str, Any]:
                 "weights per docs/hunyuan-mlx-recipes.md."
             ),
         },
-        "weights": model_availability,
+        "weights": weights_status,
         "missing_weights": missing,
         "ready": ready,
         "warning": (


### PR DESCRIPTION
## Summary

`_hunyuan_xiong_readiness()`'s `weights` field was a flat `{name: bool}` dict, but the
frontend (`viewer/index.html`) indexes into it expecting `{label, present, human}`
objects — the shape every other backend's readiness check uses (`weights_on_disk`,
built for TRELLIS). A JS boolean has no `.present`/`.label` property, so the Setup
panel always took the "missing" branch and rendered the model name as the literal
string `"undefined"`.

Reported via a real screenshot: three `⚠ undefined — not on disk` rows for the
Hunyuan3D-MLX (Xiong, full pipeline) backend, on a machine that in fact has all three
shape models downloaded (13.7 GB / 4.6 GB / 4.6 GB — confirmed directly against this
repo's actual weight directories).

These two commits were originally part of #2 but were pushed after that PR had
already been merged, so they never landed. Same fix, opened fresh.

## Test plan
- [x] `pytest tests/test_viewer_generate_api.py tests/test_viewer_serve.py` — 88 passed
- [x] `ruff check` clean
- [x] Verified directly against this repo's real Xiong shape-weight directories